### PR TITLE
Fix comments about gadgetId

### DIFF
--- a/ConnectionHelpers/DeviceSecret/README
+++ b/ConnectionHelpers/DeviceSecret/README
@@ -21,7 +21,7 @@ https://developer.amazon.com/docs/alexa-gadgets-toolkit/alexa-discovery-interfac
 
 Steps:
 1. Replace the "device_secret" char array with the device secret received from the dev portal
-2. Replace the "gadgetId" char array with the Gadget Device Id received from the dev portal.
+2. Replace the "gadgetId" char array with the endpointId that the gadget sends
 3. Save the create_secret.c file, and using a gcc compile, create the executable:
 
 gcc platform.c platform_util.c sha256.c create_secret.c -o create_secret

--- a/ConnectionHelpers/DeviceSecret/create_secret.c
+++ b/ConnectionHelpers/DeviceSecret/create_secret.c
@@ -19,7 +19,7 @@ int main()
     //Device Token Recevied from the dev-portal at gadget registration
     char* device_secret = "76AB4E896EE2A081BCAEA241058A2EEC2D016C250CF355451D7A7009A560B3F2";
 
-    //Gadget ID is the AmazonDeviceType received from the dev-portal at the time of gadget registeration
+    //Gadget ID is the endpointId (also called the device serial number (DSN)) that the gadget sends the Echo device in the Alexa.Discovery.Discover.Response event
     char* gadgetId = "G0A0B0C0D0";
 
     //The concatenated result of gadgetID and the deviceType


### PR DESCRIPTION
*Description of changes:*

The ReadMe and the comments say that the Gadget ID is the Amazon ID in the developer portal. But that's wrong.
`gadgetId` has to be the same as `endpointId` in the `Alexa.Discovery.Discover.Response` event.

This pull request fixes that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution under the terms of your choice.
